### PR TITLE
neue aliases für beer_count: drink_count, drinks

### DIFF
--- a/main.py
+++ b/main.py
@@ -333,7 +333,7 @@ async def counting_channel_error(ctx, error):
 
 # -- End Count Master Commands --
 # -- Begin Beer Count Commands --
-@bot.command(name='beer_count')
+@bot.command(name='beer_count', aliases=['drink_count', 'drinks'])
 async def beer_count(ctx, args1 = ""):
     if not isrightchannel(ctx):
         return


### PR DESCRIPTION
yep, eine Zeile geändert, man kann jetzt statt `beer_count` auch `drink_count` oder `drinks` als command nutzen